### PR TITLE
Fix RFS add/delete/zero-length file handling.

### DIFF
--- a/LazarusSource/MainUnit.pas
+++ b/LazarusSource/MainUnit.pas
@@ -6685,7 +6685,8 @@ begin
  if(not Cancel)and(NameBeforeEdit<>newfilename) then
  begin
   //Rename the file
-  if Image.MajorFormatNumber=diAcornUEF then
+  if (Image.MajorFormatNumber=diAcornUEF)
+  or (Image.MajorFormatNumber=diAcornRFS) then
    newindex:=Image.RenameFile(Node.Index,newfilename)
   else
    newindex:=Image.RenameFile(PathBeforeEdit,newfilename);


### PR DESCRIPTION
Minor fixes to RFS image handling:
* Allows inserting/renaming a file before the last file.
* Corrects offset calculations when inserting before/renaming the first file.
* Writes a header for a zero-length file.
* Omits a data CRC for zero-length files while writing and scanning the stream.
* Rearranges calls to `RFSReAdjustPointers()` so that a positive `diff` increases the link address values, fixing relinking of the files after an insertion.