### PR TITLE
Fix typo in library search path

### DIFF
--- a/LazarusSource/DiscImageManager.lpi
+++ b/LazarusSource/DiscImageManager.lpi
@@ -35,7 +35,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Debug/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -69,7 +69,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -103,7 +103,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -140,7 +140,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -176,7 +176,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -207,7 +207,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -238,7 +238,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -269,7 +269,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -300,7 +300,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -331,7 +331,7 @@
           <Version Value="11"/>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+            <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
             <UnitOutputDirectory Value="lib/Release/$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -539,7 +539,7 @@
     <Version Value="11"/>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
-      <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomConponents"/>
+      <OtherUnitFiles Value="../SpriteToBitmap;../GJHCustomComponents;../GJHCustomConponents"/>
       <UnitOutputDirectory Value="lib/Debug/$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <CodeGeneration>


### PR DESCRIPTION
Adds the non-typoed "GJHCustomComponents" search path alongside the typo-ed "GJHCustomCo**n**ponents", so both may be used interchangeably.

See #38 - which this would resolve, unless the proposed submodules change is accepted, in which case I'll gladly update this PR to include that.