### PR TITLE
Fix EStringListError crash in TRegistrySettings on second run

### DIFF
--- a/LazarusSource/DiscImageContext.pas
+++ b/LazarusSource/DiscImageContext.pas
@@ -275,11 +275,14 @@ begin
 end;
 
 procedure TRegistrySettings.SetBool(const Key: String; Value: Boolean);
+var
+  i: Integer;
+  s: String;
 begin
-  if Value then
-    FSettings.Values[Key] := 'true'
-  else
-    FSettings.Values[Key] := 'false';
+  if Value then s := 'true' else s := 'false';
+  i := FSettings.IndexOfName(Key);
+  if i >= 0 then FSettings.Delete(i);
+  FSettings.Add(Key + '=' + s);
   FModified := True;
 end;
 
@@ -295,8 +298,12 @@ begin
 end;
 
 procedure TRegistrySettings.SetInt(const Key: String; Value: Integer);
+var
+  i: Integer;
 begin
-  FSettings.Values[Key] := IntToStr(Value);
+  i := FSettings.IndexOfName(Key);
+  if i >= 0 then FSettings.Delete(i);
+  FSettings.Add(Key + '=' + IntToStr(Value));
   FModified := True;
 end;
 
@@ -308,8 +315,12 @@ begin
 end;
 
 procedure TRegistrySettings.SetString(const Key: String; const Value: String);
+var
+  i: Integer;
 begin
-  FSettings.Values[Key] := Value;
+  i := FSettings.IndexOfName(Key);
+  if i >= 0 then FSettings.Delete(i);
+  FSettings.Add(Key + '=' + Value);
   FModified := True;
 end;
 


### PR DESCRIPTION
FPC's sorted TStringList raises "Operation not allowed on sorted list" when Strings[i] is assigned directly (via Values[key] := v) and the key already exists. On the second run the settings file is loaded first, so every SetBool/SetInt/SetString call on an existing key triggered the exception immediately.

Fix: use IndexOfName+Delete+Add instead of Values[key]:= in all three setters, which is safe for sorted lists.


Claude-Session: https://claude.ai/code/session_012c5TpXWmyNtRKUpEUR6pUK